### PR TITLE
removed duplicate querys in blog layout

### DIFF
--- a/plugins/cck_storage_location/joomla_article/joomla_article.php
+++ b/plugins/cck_storage_location/joomla_article/joomla_article.php
@@ -372,7 +372,7 @@ class plgCCK_Storage_LocationJoomla_Article extends JCckPluginLocation
 			$table->load( $pk );
 			if ( $table->id ) {
 				if ( $join ) { // todo:join
-					$join					=	JCckDatabase::loadObject( 'SELECT a.title, a.alias FROM #__categories AS a WHERE a.id = '.$table->catid );	//@
+					$join					=	JCckDatabaseCache::loadObject( 'SELECT a.title, a.alias FROM #__categories AS a WHERE a.id = '.$table->catid );	//@
 					if ( is_object( $join ) && isset( $join->title ) ) {
 						$table->category_title	=	$join->title;
 						$table->category_alias	=	$join->alias;


### PR DESCRIPTION
When using standard Joomla Blog layout i've had like 10+ duplicate query's listed in debug mode. This patch reduced that to zero.
I couldn't find any place where this->cache was set so I decided to remove

Sorry for duplicate request, i had some trouble with my email-config.