### PR TITLE
Update on JCckContent to support content type without extra table

### DIFF
--- a/libraries/cms/cck/content.php
+++ b/libraries/cms/cck/content.php
@@ -70,7 +70,9 @@ class JCckContent
 		
 		$this->_type	=	$cck;
 		$this->_instance_core	=	JTable::getInstance( $this->_object_table[$this->_object] );
-		$this->_instance_more	=	JCckTable::getInstance( '#__cck_store_form_'.$this->_type );
+		if ( is_array( $data_more ) ) { // Note: Not All Content Type have extra table
+			$this->_instance_more	=	JCckTable::getInstance( '#__cck_store_form_'.$this->_type );
+		}
 		
 		$author_id 		=	0; // TODO : Get default author id
 		$parent_id		=	0;

--- a/libraries/cms/cck/dev/helper.php
+++ b/libraries/cms/cck/dev/helper.php
@@ -102,7 +102,8 @@ abstract class JCckDevHelper
 	// getRelativePath
 	public static function getRelativePath( $path, $prepend = true )
 	{
-		$path	=	str_ireplace( JPATH_ROOT, '', $path );
+		$root=str_replace( '\\', '/', JPATH_ROOT ); //on Windows, JPATH_ROOT is using '\' instead of '/', we need to force it
+		$path	=	str_ireplace( $root, '', $path );
 		$path	=	str_replace( '\\', '/', $path );
 		
 		if ( !$path ) {


### PR DESCRIPTION
If parameter $data_more is null, there's no use to load extra CT Table. And also, not content type use extra table.