### PR TITLE
Fix missing include when validation is used as standalone (outside cck component)

### DIFF
--- a/libraries/cms/cck/dev.php
+++ b/libraries/cms/cck/dev.php
@@ -390,7 +390,10 @@ abstract class JCckDev
 		$config['validation']			=	count( $config['validation'] ) ? implode( ',', $config['validation'] ) : '"null":{}';
 		$config['validation_options']	=	new JRegistry( array( 'validation_background_color'=>'#242424', 'validation_color'=>'#ffffff', 'validation_position'=>'topRight', 'validation_scroll'=>0 ) );
 		
-		// require_once JPATH_BASE.'/components/com_cck/helpers/helper_include.php'; // todo: include for manual use of JCckDev (but not for add-on.. :/)
+		if (!class_exists('Helper_Include'))
+		{
+			require_once JPATH_BASE.'/components/com_cck/helpers/helper_include.php';
+		}
 		
 		Helper_Include::addValidation( $config['validation'], $config['validation_options'], $id );
 		


### PR DESCRIPTION
Auto add include if class does not exist