### PR TITLE
Update cck.admin.css

### DIFF
--- a/media/cck/css/cck.admin.css
+++ b/media/cck/css/cck.admin.css
@@ -28,7 +28,7 @@ div.vertical div.cck_forms{float:left;padding-bottom:10px;width:100%;}
 div.horizontal div.cck_forms{float:left;padding-bottom:10px;width:auto;}
 div.cck_forms.cck_admin div.cck_label{float:left;line-height:25px;width:145px;}
 div.cck_forms.cck_admin div.cck_form a.cck_preview,div.cck_forms.cck_admin div.cck_form span.cck_preview{float:left;line-height:25px;width:145px;}
-div.cck_forms.cck_admin div.cck_form{float:left;width:auto;}
+div.cck_forms.cck_admin div.cck_form{float: none;width:auto;margin: 10px 0 0 0;}
 div.cck_forms.cck_admin div.cck_desc{clear:both;width:auto;}
 div.cck_forms.cck_admin div.cck_desc p{ margin:8px 0px 0px 0px;}
 div.vertical div.cck_forms.cck_admin div.cck_label { width: 145px; text-align: left; padding: 0px 0px 0px 0px; }


### PR DESCRIPTION


I found that in the backend interface for any form type, fields would suddenly all fall into one line, instead of one line per label/ field. I think this change happened with jSeblod 3.7

I cannot find any change to this file for over 1 year, but I know the issue happened in the past 2 months, therefore I assume this is a regression from some other change.

My change fixes the issue and also creates a small amount of space between field rows.

I have taken screenshots before and after:

![jseblod before](https://cloud.githubusercontent.com/assets/2119862/9776399/e1ebc708-57ab-11e5-995d-9bab4f7346d3.png)

![jseblod after](https://cloud.githubusercontent.com/assets/2119862/9776398/e1e86e64-57ab-11e5-9520-b2fc0c47dbf8.png)

Jochen