### PR TITLE
Adding a semi-colon to the end of the JCck.Dev.Close function declara…

### DIFF
--- a/administrator/components/com_cck/views/box/tmpl/edit.php
+++ b/administrator/components/com_cck/views/box/tmpl/edit.php
@@ -75,7 +75,7 @@ if ( $this->doValidation == 1 ) {
 }
 $js		=	'if("undefined"===typeof JCck.Dev){JCck.Dev={}};'
 		.	'JCck.Dev.close = function() { if (parent.jQuery.fn.colorbox) {parent.jQuery.fn.colorbox.close();}'
-		.	'else {if (window.parent.SqueezeBox) {window.parent.SqueezeBox.close();};} }';
+		.	'else {if (window.parent.SqueezeBox) {window.parent.SqueezeBox.close();};} };';
 $doc->addScriptDeclaration( $js );
 ?>
 </form>


### PR DESCRIPTION
…tion to fix javascript error

If javascript is injected after this code from other plugins running JDocument::addScriptDeclaration it will cause a javascript error that causes modal boxes to close instant. Adding this semi-colon protects against that error.