### PR TITLE
Add btn-default class in calendar button

### DIFF
--- a/plugins/cck_field/calendar/calendar.php
+++ b/plugins/cck_field/calendar/calendar.php
@@ -116,7 +116,7 @@ class plgCCK_FieldCalendar extends JCckPluginField
 		// Set
 		if ( ! $field->variation ) {
 			if ( JCck::on() ) {
-				$form		.=	'<button class="btn" id="'.$id.'-trigger"><span class="icon-calendar"></span></button>';
+				$form		.=	'<button class="btn btn-default" id="'.$id.'-trigger"><span class="icon-calendar"></span></button>';
 			} else {
 				$form		.=	'<img src="'.self::$path.'assets/images/calendar.png" alt="Calendar" class="calendar" id="'.$id.'-trigger" />';	
 			}


### PR DESCRIPTION
In bootstrap, only btn doesn't work, I just added the class btn-default.