### PR TITLE
remove birthdate and birthplace from 2.6.0 update sql - fixes #134

### DIFF
--- a/administrator/components/com_cck/install/upgrades/2.6.0.sql
+++ b/administrator/components/com_cck/install/upgrades/2.6.0.sql
@@ -48,9 +48,7 @@ CREATE TABLE IF NOT EXISTS `#__cck_store_item_users` (
   `region` varchar(255) NOT NULL,
   `country` varchar(255) NOT NULL,
   `phone` varchar(255) NOT NULL,
-  `website` varchar(255) NOT NULL,
-  `birthdate` datetime NOT NULL,
-  `birthplace` varchar(255) NOT NULL,
+  `website` varchar(255) NOT NULL
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
remove birthdate and birthplace from 2.6.0 update sql to allow 3.2.0 update sql to work
fixes #134