### PR TITLE
fix edit button on user profile, resolves #132

### DIFF
--- a/plugins/content/cck/cck.php
+++ b/plugins/content/cck/cck.php
@@ -221,6 +221,7 @@ class plgContentCCK extends JPlugin
 	// _prepare
 	protected function _prepare( $context, &$article, &$params, $page = 0 )
 	{
+		$originalId = $article->id;
 		$property	=	'text';
 		preg_match( '#::cck::(.*)::/cck::#U', $article->$property, $matches );
 	  	if ( ! @$matches[1] ) {
@@ -363,6 +364,9 @@ class plgContentCCK extends JPlugin
 		}
 		
 		$this->_render( $context, $article, $tpl, $contentType, $fields, $property, $client, $cck, $parent_type );
+
+		$article->id = $originalId;
+
 	}
 	
 	// _process

--- a/plugins/system/cck/cck.php
+++ b/plugins/system/cck/cck.php
@@ -370,7 +370,6 @@ class plgSystemCCK extends JPlugin
 			if ( $option == 'com_users' ) {
 				$options	=	JCckDatabase::loadResult( 'SELECT a.options FROM #__cck_core_objects AS a WHERE a.name = "joomla_user"' );
 				$options	=	new JRegistry( $options );
-				$itemId		=	$app->input->getInt( 'Itemid', 0 );
 				
 				if ( $options->get( 'registration', 1 ) ) {
 					if ( $view == 'profile' ) {
@@ -423,17 +422,28 @@ class plgSystemCCK extends JPlugin
 			}
 			
 			if ( $option == 'com_content' && $view == 'form' && $layout == 'edit' ) {
-				$itemId	=	$app->input->getInt( 'Itemid', 0 );
 				$aid	=	$app->input->getInt( 'a_id', 0 );
 				$return	=	$app->input->getBase64( 'return' );
 				if ( !$aid ) {
 					return;
 				}
-				$type	=	JCckDatabase::loadResult( 'SELECT cck FROM #__cck_core WHERE storage_location="joomla_article" AND pk='.(int)$aid );
-				if ( !$type ) {
-					return;
+				$userType = JCckDatabase::loadObject( 'SELECT cck,pk FROM #__cck_core WHERE storage_location="joomla_user" AND pkb='.(int)$aid );
+
+				if ($userType)
+				{
+					$type = $userType->cck;
+					$aid  = (int)$userType->pk;
+				}
+				else
+				{
+					$type	=	JCckDatabase::loadResult( 'SELECT cck FROM #__cck_core WHERE storage_location="joomla_article" AND pk='.(int)$aid );
+					if ( !$type ) {
+						return;
+					}
+
 				}
 				$url	=	'index.php?option=com_cck&view=form&layout=edit&type='.$type.'&id='.$aid.'&Itemid='.$itemId.'&return='.$return;
+
 				$app->redirect( $url );
 			}
 			


### PR DESCRIPTION
Fix edit button leading to wrong content type&wrong id when editing user profile with bridge enabled.
Resolves #132

## This pull needs to be reviewed carefully
- reverting article id at the end of  _prepare could have unwanted side-effects (I don't know why it was done so in the first place)