### PR TITLE
fix error in one child breaking upload for others

### DIFF
--- a/plugins/cck_field/upload_file/upload_file.php
+++ b/plugins/cck_field/upload_file/upload_file.php
@@ -415,10 +415,16 @@ class plgCCK_FieldUpload_File extends JCckPluginField
 			$array_x	=	( isset( $inherit['array_x'] ) ) ? $inherit['array_x'] : 0;
 			$itemPath	=	( isset( $inherit['post'] ) ) ? $inherit['post'][$name.'_hidden'] : @$config['post'][$name.'_hidden'];
 			$deleteBox	=	( isset( $inherit['post'] ) ) ? @$inherit['post'][$name.'_delete'] : @$config['post'][$name.'_delete'];
+
 			if ( $options2['multivalue_mode'] ) {
 				$item_custom_dir	.=	( isset( $inherit['post'] ) ) ? $inherit['post'][$name.'_path'] : @$config['post'][$name.'_path'];
 				$item_custom_title	=	( isset( $inherit['post'] ) )	? @$inherit['post'][$name.'_title'] 	: @$config['post'][$name.'_title'];
 			}
+
+			if ( isset( $field->error ) && $field->error === true ) {
+				$field->error = false;
+			}
+
 		} else {
 			$name		=	$field->name;
 			$xk			=	-1;

--- a/plugins/cck_field/upload_image/upload_image.php
+++ b/plugins/cck_field/upload_image/upload_image.php
@@ -434,6 +434,7 @@ class plgCCK_FieldUpload_Image extends JCckPluginField
 		// Init
 		$app		=	JFactory::getApplication();
 		$options2	=	JCckDev::fromJSON( $field->options2 );
+
 		if ( count( $inherit ) ) {
 			$name		=	( isset( $inherit['name'] ) && $inherit['name'] != '' ) ? $inherit['name'] : $field->name;
 			$xk			=	( isset( $inherit['xk'] ) ) ? $inherit['xk'] : -1;
@@ -445,6 +446,11 @@ class plgCCK_FieldUpload_Image extends JCckPluginField
 			$imageTitle	=	( isset( $inherit['post'] ) )	? @$inherit['post'][$name.'_title'] 	: @$config['post'][$name.'_title'];
 			$imageDesc	=	( isset( $inherit['post'] ) )	? @$inherit['post'][$name.'_description'] 	: @$config['post'][$name.'_description'];
 			$imageCustomDir	=	( isset( $inherit['post'] ) ) ? @$inherit['post'][$name.'_path'] : @$config['post'][$name.'_path'];
+
+			if ( isset( $field->error ) && $field->error === true ) {
+				$field->error = false;
+			}
+
 		} else {
 			$name		=	$field->name;
 			$xk			=	-1;


### PR DESCRIPTION
When upload image/files is used a s field x, error in one image (e.g. due to size) breaks upload also for other images.
Fixes #101 