### PR TITLE
load TagsHelperRuoute to prevent fatal error in backend

### DIFF
--- a/plugins/cck_field/jform_tag/jform_tag.php
+++ b/plugins/cck_field/jform_tag/jform_tag.php
@@ -38,6 +38,8 @@ class plgCCK_FieldJform_Tag extends JCckPluginField
 			return;
 		}
 		parent::g_onCCK_FieldPrepareContent( $field, $config );
+		
+		JLoader::register('TagsHelperRoute', JPATH_SITE . '/components/com_tags/helpers/route.php');
 
 		$html	=	'';
 


### PR DESCRIPTION
Joomla tries to load this class from wrong place as jpath_base resolves to administrator in backend..

Reference http://www.seblod.com/community/forums/fields-plug-ins/article-tags-in-combination-with-smart-search-error#post43135