### PR TITLE
Fix JHtml error

### DIFF
--- a/plugins/cck_field_typo/joomla_jgrid/joomla_jgrid.php
+++ b/plugins/cck_field_typo/joomla_jgrid/joomla_jgrid.php
@@ -101,10 +101,10 @@ class plgCCK_Field_TypoJoomla_Jgrid extends JCckPluginTypo
 				}
 				break;
 			case 'featured':
-				static $loaded = 0;
-				if ( !$loaded ) {
+				static $loadedF = 0;
+				if ( !$loadedF ) {
 					JHtml::addIncludePath( JPATH_ADMINISTRATOR.'/components/com_content/helpers/html' );
-					$loaded	=	1;
+					$loadedF	=	1;
 				}
 				$value		=	JHtml::_( 'contentadministrator.featured', $field->value, $pks[$pk], false /*$canChange*/ );
 				if ( JCck::on() ) {


### PR DESCRIPTION
Fix 
An error has occurred.

    500 JHtml contentadministrator not found. 

Error occurs in admin when Reordering is used together with featured as there are 2 static variables with name $loaded.