### PR TITLE
fix redirect with sef deactivated

### DIFF
--- a/libraries/cck/base/list/list.php
+++ b/libraries/cck/base/list/list.php
@@ -394,7 +394,7 @@ class CCK_List
 		}
 		
 		if ( $action == 'redirection' ) {
-			$url	=	( $url != 'index.php' ) ? JRoute::_( $url ) : $url;
+			$url	=	( $url != 'index.php' ) ? JRoute::_( $url, false ) : $url;
 			$app->redirect( $url );
 		}
 	}

--- a/plugins/cck_storage_location/joomla_article/joomla_article.php
+++ b/plugins/cck_storage_location/joomla_article/joomla_article.php
@@ -731,7 +731,7 @@ class plgCCK_Storage_LocationJoomla_Article extends JCckPluginLocation
 			$route		=	ContentHelperRoute::getArticleRoute( $item->slug, $item->catid, $item->language );
 		}
 		
-		return JRoute::_( $route );
+		return JRoute::_( $route, false );
 	}
 	
 	// getRouteByStorage
@@ -797,7 +797,7 @@ class plgCCK_Storage_LocationJoomla_Article extends JCckPluginLocation
 			$storage[self::$table]->_route[$idx]	=	ContentHelperRoute::getArticleRoute( $storage[self::$table]->slug, $storage[self::$table]->catid, $storage[self::$table]->language );
 		}
 		
-		return JRoute::_( $storage[self::$table]->_route[$idx] );
+		return JRoute::_( $storage[self::$table]->_route[$idx], false );
 	}
 
 	// parseRoute


### PR DESCRIPTION
Fix auto redirect that redirects to url  `&amp` instead of &, causing problems with some servers

Added same change to other instances, this will only affect non-sef urls.

Reference
https://www.seblod.com/community/forums/lists-search-types/auto-redirection-url-issue
