### PR TITLE
Changing language files for the new core plugins integrated in SEBLOD 3.8

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_cck_field_button_free.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_button_free.ini
@@ -7,7 +7,7 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_BUTTON_FREE="Free Button Field Plug-in for SEBLOD"
+PLG_CCK_FIELD_BUTTON_FREE="CCK Field - Button Free"
 PLG_CCK_FIELD_BUTTON_FREE_LABEL="Free"
 PLG_CCK_FIELD_BUTTON_FREE_LABEL2="Button Free"
 PLG_CCK_FIELD_BUTTON_FREE_DESC="Button Free.."

--- a/administrator/language/en-GB/en-GB.plg_cck_field_button_free.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_button_free.sys.ini
@@ -7,4 +7,4 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_BUTTON_FREE="Free Button Field Plug-in for SEBLOD"
+PLG_CCK_FIELD_BUTTON_FREE="CCK Field - Button Free"

--- a/administrator/language/en-GB/en-GB.plg_cck_field_restriction_url_variable.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_restriction_url_variable.ini
@@ -7,7 +7,7 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_RESTRICTION_URL_VARIABLE="Url Variable Restriction Plug-in for SEBLOD"
+PLG_CCK_FIELD_RESTRICTION_URL_VARIABLE="CCK Field Restriction - Url Variable"
 PLG_CCK_FIELD_RESTRICTION_URL_VARIABLE_LABEL="Url Variable"
 PLG_CCK_FIELD_RESTRICTION_URL_VARIABLE_DESC="Url Variable.."
 PLG_CCK_FIELD_RESTRICTION_GROUP_NONE="-"

--- a/administrator/language/en-GB/en-GB.plg_cck_field_restriction_url_variable.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_restriction_url_variable.sys.ini
@@ -7,4 +7,4 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_RESTRICTION_URL_VARIABLE="Url Variable Restriction Plug-in for SEBLOD"
+PLG_CCK_FIELD_RESTRICTION_URL_VARIABLE="CCK Field Restriction - Url Variable"

--- a/administrator/language/en-GB/en-GB.plg_cck_field_search_generic.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_search_generic.ini
@@ -7,7 +7,7 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_SEARCH_GENERIC="Search Generic Field Plug-in for SEBLOD"
+PLG_CCK_FIELD_SEARCH_GENERIC="CCK Field - Search Generic"
 PLG_CCK_FIELD_SEARCH_GENERIC_LABEL="Generic"
 PLG_CCK_FIELD_SEARCH_GENERIC_LABEL2="Search Generic"
 PLG_CCK_FIELD_SEARCH_GENERIC_DESC="Search Generic.."

--- a/administrator/language/en-GB/en-GB.plg_cck_field_search_generic.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_search_generic.sys.ini
@@ -7,4 +7,4 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_SEARCH_GENERIC="Search Generic Field Plug-in for SEBLOD"
+PLG_CCK_FIELD_SEARCH_GENERIC="CCK Field - Search Generic"

--- a/administrator/language/en-GB/en-GB.plg_cck_field_search_ordering.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_search_ordering.ini
@@ -7,7 +7,7 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_SEARCH_ORDERING="Search Ordering Field Plug-in for SEBLOD"
+PLG_CCK_FIELD_SEARCH_ORDERING="CCK Field - Search Ordering"
 PLG_CCK_FIELD_SEARCH_ORDERING_LABEL="Ordering"
 PLG_CCK_FIELD_SEARCH_ORDERING_LABEL2="Search Ordering"
 PLG_CCK_FIELD_SEARCH_ORDERING_DESC="Search Ordering.."

--- a/administrator/language/en-GB/en-GB.plg_cck_field_search_ordering.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_cck_field_search_ordering.sys.ini
@@ -7,4 +7,4 @@
 ; @license 			GNU General Public License version 2 or later; see _LICENSE.php
 ;
 
-PLG_CCK_FIELD_SEARCH_ORDERING="Search Ordering Field Plug-in for SEBLOD"
+PLG_CCK_FIELD_SEARCH_ORDERING="CCK Field - Search Ordering"


### PR DESCRIPTION
since 3.8.0 they are 5 Plugins merged into the core. My suggestion is to change the strings of 4 of them in that language files to following:

```
Free Button Field Plug-in for SEBLOD => CCK Field - Button Free
Url Variable Restriction Plug-in for SEBLOD => CCK Field Restriction - Url Variable
Search Generic Field Plug-in for SEBLOD => CCK Field - Search Generic
Search Ordering Field Plug-in for SEBLOD => CCK Field - Search Ordering
```

This gives in my opinion a more conform classification of which plugin is a core plugin, because all other core plugins have the same typography.

I have changed the english strings only. For france there must be another team member go in action.
