### PR TITLE
Fix Issue #365

### DIFF
--- a/plugins/cck_storage_location/joomla_user/classes/exporter.php
+++ b/plugins/cck_storage_location/joomla_user/classes/exporter.php
@@ -16,7 +16,7 @@ require_once JPATH_SITE.'/plugins/cck_storage_location/joomla_user/joomla_user.p
 class plgCCK_Storage_LocationJoomla_User_Exporter extends plgCCK_Storage_LocationJoomla_User
 {
 	protected static $columns_excluded	=	array( 'isRoot', 'password_clear', 'usertype', 'guest', 'aid', 'userHelper' );
-	protected static $columns_ignored	=	array( 'isRoot', 'id', 'password', 'password_clear', 'usertype', 'guest', 'aid', 'userHelper' );
+	protected static $columns_ignored	=	array( 'isRoot', 'id', 'password', 'password_clear', 'usertype', 'guest', 'aid', 'userHelper','otpKey','otep');
 
 	// getColumnsToExport
 	public static function getColumnsToExport()


### PR DESCRIPTION
Latest Joomla has 2 new field that not registered in seblod user object export, i'll update the excluded field, and the problem is gone.

To All User: This kind of issue is related with core Joomla. If Joomla team decide to add/remove field in #__users table, this 'bug' will arise again. So hopefully, as community, if you happen upgrade joomla to newer version than 3.6.5, please check #__users and let us know if the team made changes on this table.