### PR TITLE
Fix "not authorized" messages due to client mismatch in upload file

### DIFF
--- a/plugins/cck_field/upload_file/upload_file.php
+++ b/plugins/cck_field/upload_file/upload_file.php
@@ -348,7 +348,9 @@ class plgCCK_FieldUpload_File extends JCckPluginField
 			$more	=	( $collection ) ? '&collection='.$collection.'&xi='.$xk : '';
 			$label	=	JText::_( 'COM_CCK_PREVIEW' );
 			if ( isset( $config['id'] ) && $config['id'] ) {
-				$link	=	JRoute::_( 'index.php?option=com_cck&task=download'.$more.'&file='.( ( !$config['client'] && $inherit['name'] ) ? $inherit['name'] : $field->name ).'&id='.$config['id'] );
+				$link	=	JRoute::_( 'index.php?option=com_cck&task=download&client='.($config['client'] ? $config['client'] : 'site'). 
+						                 $more.'&file='.( ( !$config['client'] && $inherit['name'] ) ? $inherit['name'] : $field->name ).
+						                 '&id='.$config['id'] );
 				$target	=	'';
 			} else {
 				$link	=	JUri::root().$value2;


### PR DESCRIPTION
When user is previewing uploaded file from form default content client is being used as it is missing in the link, resulting in non-authorized messages if field is not also added to the content tab of the type.

https://www.seblod.com/community/forums/fields-plug-ins/you-are-not-allowed-to-access-this-file#post55714
https://www.seblod.com/community/forums/fields-plug-ins/upload-file-755-permissions#post55729