### PR TITLE
Avoid "Error: 0" when an empty date is edited

### DIFF
--- a/plugins/cck_field/calendar/calendar.php
+++ b/plugins/cck_field/calendar/calendar.php
@@ -106,7 +106,7 @@ class plgCCK_FieldCalendar extends JCckPluginField
 		}
 
 
-		if ( empty( $value ) || $value == '0000-00-00 00:00:00' ) {
+		if ( empty( $value ) || $value == '0000-00-00 00:00:00' || $value == '0000-00-00' ) {
 			$hiddenValue		=	'';
 			$displayValue		=	'';
 			$scriptDate         =	'';


### PR DESCRIPTION
Running Seblod 3.15.0 and Joomla 3.8.2:

When I edit a form wich has a calendar field, not filled when it was submitted, has this value: "-0001-11-30".
Then, when we try to save the form, the following error appears:

Error: 0 - You either used wrong format or locale set by language file is not supported on your server - es_ES.utf8

The calendar field format is "Y-m-d", the storage format "Datetime" and its value is 0000-00-00 in the database (mysql date field format, not datetime format), then if we add: "or if date = 0000-00-00" the problem is fixed.

Thank you.