### PR TITLE
Make html typo work with link

### DIFF
--- a/plugins/cck_field_link/content/content.php
+++ b/plugins/cck_field_link/content/content.php
@@ -302,7 +302,7 @@ class plgCCK_Field_LinkContent extends JCckPluginLink
 			if ( strpos( $fields[$name]->typo, $fields[$name]->$target ) === false ) {
 				$fields[$name]->typo	=	$html;
 			} else {
-				$fields[$name]->typo	=	str_replace( $fields[$name]->$target, $html, $fields[$name]->typo );
+				$fields[$name]->typo	=	str_replace( $fields[$name]->$target, $fields[$name]->typo, $html );
 			}
 		}
 		if ( isset( $process['matches'] ) && count( $process['matches'][1] ) ) {


### PR DESCRIPTION
Arguments order in str_replace needs to be reversed, typo needs to be pushed into html not the other way around.
Example:
A field with value "icon-activated-zeolites" and html typography <span class="*value*"></span> has link applied.
At line 305 values are:
`typo = <span class='icon-activated-zeolites'></span>
$html = <a href="/somelink">icon-activated-zeolites</a>
value = icon-activated-zeolites`


Before change this produces `typo = <span class='<a href="/silkem17/index.php/de/produkte/32-aktivirani-zeoliti">icon-activated-zeolites</a>'></span>`.

After change type is as it is supposed to be:
`<a href="/somelink"><span class='icon-activated-zeolites'></span></a>`