### PR TITLE
Implement access to $config variable in replaceLive function

### DIFF
--- a/libraries/cms/cck/dev/helper.php
+++ b/libraries/cms/cck/dev/helper.php
@@ -661,9 +661,20 @@ abstract class JCckDevHelper
 			preg_match_all( $search, $str, $matches );
 			if ( count( $matches[1] ) ) {
 				foreach ( $matches[1] as $k=>$v ) {
-					$v2		=	( isset( $site->$v ) ) ? $site->$v : '';
+					$v2	=	( isset( $site->$v ) ) ? $site->$v : '';
 					$str	=	str_replace( $matches[0][$k], $v2, $str );
 				}
+			}
+		}
+		if ( $str != '' && strpos( $str, '$config' ) !== false ) {
+			$matches		=	'';
+			$search			=	'#\$config\[\'([a-zA-Z0-9_]*)\'\]#';
+			preg_match_all( $search, $str, $matches );
+			if ( count( $matches[1] ) ) {
+				foreach ( $matches[1] as $k=>$v ) {
+					$v2	=	( isset( $config[$v] ) ) ? $config[$v] : '';
+					$str	=	str_replace( $matches[0][$k], $v2, $str );
+        			}
 			}
 		}
 		if ( $str != '' && strpos( $str, 'J(' ) !== false ) {


### PR DESCRIPTION
Further to my question in the forums https://www.seblod.com/community/forums/fields-plug-ins/what-variables-are-accessible-to-select-dynamic, I have implemented the ability to access the $config variable in the replaceLive function. I feel this would be useful to a wider audience, hence this PR.