### PR TITLE
Change defaultvalue column to text datatype in cck_core_fields table

### DIFF
--- a/administrator/components/com_cck/install/install.sql
+++ b/administrator/components/com_cck/install/install.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS `#__cck_core_fields` (
   `display` int(11) NOT NULL DEFAULT '0',
   `required` varchar(50) NOT NULL,
   `validation` varchar(50) NOT NULL,
-  `defaultvalue` varchar(2048) NOT NULL,
+  `defaultvalue` text NOT NULL,
   `options` text NOT NULL COMMENT 'string-formated options',
   `options2` text NOT NULL COMMENT 'json-formated options',
   `minlength` int(11) NOT NULL DEFAULT '0',


### PR DESCRIPTION
My JS code was getting truncated when saving so I have adjusted the datatype of the field to text instead of varchar(2048). See https://www.seblod.com/community/forums/fields-plug-ins/field-script-js-lines-limit for more details.