### PR TITLE
Remove bad and non-printing characters in Upload Image plugin

### DIFF
--- a/plugins/cck_field/upload_image/upload_image.php
+++ b/plugins/cck_field/upload_image/upload_image.php
@@ -118,6 +118,20 @@ class plgCCK_FieldUpload_Image extends JCckPluginField
 		
 		// Set
 		$isDefault		=	false;
+
+		// Remove bad characters
+		$chars = [
+			// control characters
+			chr(0), chr(1), chr(2), chr(3), chr(4), chr(5), chr(6), chr(7), chr(8), chr(9), chr(10),
+			chr(11), chr(12), chr(13), chr(14), chr(15), chr(16), chr(17), chr(18), chr(19), chr(20),
+			chr(21), chr(22), chr(23), chr(24), chr(25), chr(26), chr(27), chr(28), chr(29), chr(30),
+			chr(31),
+			// non-printing characters
+			chr(127)
+		];
+
+		$value = str_replace($chars, '', $value);
+
 		$value_json		=	JCckDev::fromJSON( $value );
 		$options2		=	JCckDev::fromJSON( $field->options2 );
 

--- a/plugins/cck_field/upload_image/upload_image.php
+++ b/plugins/cck_field/upload_image/upload_image.php
@@ -259,6 +259,20 @@ class plgCCK_FieldUpload_Image extends JCckPluginField
 		if ( $value == '') {
 			$value	=	array( 'image_location'=>'', 'image_title'=>'', 'image_description'=>'' );
 		} else {
+
+			// Remove bad characters
+			$chars = [
+				// control characters
+				chr(0), chr(1), chr(2), chr(3), chr(4), chr(5), chr(6), chr(7), chr(8), chr(9), chr(10),
+				chr(11), chr(12), chr(13), chr(14), chr(15), chr(16), chr(17), chr(18), chr(19), chr(20),
+				chr(21), chr(22), chr(23), chr(24), chr(25), chr(26), chr(27), chr(28), chr(29), chr(30),
+				chr(31),
+				// non-printing characters
+				chr(127)
+			];
+
+			$value = str_replace($chars, '', $value);
+
 			$value_json	=	JCckDev::fromJSON( $value );
 			if ( is_array( $value_json ) && !empty( $value_json ) ) {
 				$value_json['image_location']	=	trim( $value_json['image_location'] );


### PR DESCRIPTION
Fix: Error decoding JSON data: Control character error, possibly incorrectly encoded

If past non-printing characters in alt or title for image.

For example:

`{"image_location":"images/blogs/_cover/838/30008/ai.jpg","image_title":"Олександр Усик, фото прес-служба ФБУ	","image_description":""}`