### PR TITLE
Add article alias in building article SEF route when missing

### DIFF
--- a/plugins/cck_field/checkbox/checkbox.php
+++ b/plugins/cck_field/checkbox/checkbox.php
@@ -199,9 +199,9 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 				} else {
 					$checked	=	'';
 				}
-				$form		.=	'<input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
 
-				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label>';
+				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
 			}
 			$form		.=	'</div>';
 		} else {
@@ -225,16 +225,16 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 					} else {
 						$checked	=	'';
 					}
-					$form		.=	'<input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label>';
+					$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
 				}
 			}
 		}
 		if ( $field->bool7 ) {
 			$checked	=	( $count == $count2 ? '1' : '' ) ? 'checked="checked" ' : '';
 			$attr		=	'onclick="Joomla.checkAll(this,\''.$id.'\');"';
-			$check_all	=	'<input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
-						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label>';
+			$check_all	=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
+						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label></span>';
 			if ( $field->bool && $field->bool2 > 1 && $count > 1 ) {
 				$check_all	=	'<div class="cck-clrfix">'.$check_all.'</div>';
 			}

--- a/plugins/cck_field/checkbox/checkbox.php
+++ b/plugins/cck_field/checkbox/checkbox.php
@@ -199,9 +199,9 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 				} else {
 					$checked	=	'';
 				}
-				$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
 
-				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
+				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label>';
 			}
 			$form		.=	'</div>';
 		} else {
@@ -225,16 +225,16 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 					} else {
 						$checked	=	'';
 					}
-					$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
+					$form		.=	'<input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label>';
 				}
 			}
 		}
 		if ( $field->bool7 ) {
 			$checked	=	( $count == $count2 ? '1' : '' ) ? 'checked="checked" ' : '';
 			$attr		=	'onclick="Joomla.checkAll(this,\''.$id.'\');"';
-			$check_all	=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
-						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label></span>';
+			$check_all	=	'<input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
+						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label>';
 			if ( $field->bool && $field->bool2 > 1 && $count > 1 ) {
 				$check_all	=	'<div class="cck-clrfix">'.$check_all.'</div>';
 			}

--- a/plugins/cck_storage_location/joomla_article/joomla_article.php
+++ b/plugins/cck_storage_location/joomla_article/joomla_article.php
@@ -729,6 +729,18 @@ class plgCCK_Storage_LocationJoomla_Article extends JCckPluginLocation
 		if ( isset( $query['id'] ) ) {
 			if ( self::$sef[$config['doSEF']] == 'full' ) {
 				$id		=	$query['id'];
+				// Make sure we have the id and the alias
+				if (strpos($query['id'], ':') === false)
+				{
+					$db = JFactory::getDbo();
+					$dbQuery = $db->getQuery(true)
+						->select('alias')
+						->from('#__content')
+						->where('id=' . (int) $query['id']);
+					$db->setQuery($dbQuery);
+					$alias = $db->loadResult();
+					$id = $id . ':' . $alias;
+				}
 			} else {
 				if ( strpos( $query['id'], ':' ) !== false ) {
 					$idArray	=	explode( ':', $query['id'], 2 );


### PR DESCRIPTION
Like com_content router does, when invoking JRoute on an article view, if just the id is passed and not the full slug (id:alias), the component router should add the alias. This is important since when SEF is the default "id-alias", it should not be mandatory to write a link with the alias since it can be changed in the future and that will produce a broken link in Seblod with 404 Error.
This PR retrieve article alias from #__content and adds it to the article id if the alias is missing. 
@sebastienheraud: can you check if this addition is correctly placed in `$config['doSEF'] == 'full'` condition? thanks