### PR TITLE
make article SEF routing independent from article alias

### DIFF
--- a/plugins/cck_storage_location/joomla_article/joomla_article.php
+++ b/plugins/cck_storage_location/joomla_article/joomla_article.php
@@ -729,6 +729,18 @@ class plgCCK_Storage_LocationJoomla_Article extends JCckPluginLocation
 		if ( isset( $query['id'] ) ) {
 			if ( self::$sef[$config['doSEF']] == 'full' ) {
 				$id		=	$query['id'];
+				// Make sure we have the id and the alias
+				if (strpos($query['id'], ':') === false)
+				{
+					$db = JFactory::getDbo();
+					$dbQuery = $db->getQuery(true)
+						->select('alias')
+						->from('#__content')
+						->where('id=' . (int) $query['id']);
+					$db->setQuery($dbQuery);
+					$alias = $db->loadResult();
+					$id = $id . ':' . $alias;
+				}
 			} else {
 				if ( strpos( $query['id'], ':' ) !== false ) {
 					$idArray	=	explode( ':', $query['id'], 2 );


### PR DESCRIPTION
In com_content router, when invoking JRoute on an article view, if just the article id is passed and not the full slug (id:alias), the component router adds the alias. This PR replicates this feature in Seblod article routing and it is important since when SEF is the default "id-alias", it should not be mandatory to include the alias in the RAW URL passed to the router since the alias may change in the future and that would produce a broken URL in Seblod with 404 Error.
This PR retrieve article alias from #__content and adds it to the article id if the alias is missing.