### PR TITLE
add a class to each checkbox and radio option

### DIFF
--- a/plugins/cck_field/checkbox/checkbox.php
+++ b/plugins/cck_field/checkbox/checkbox.php
@@ -199,7 +199,7 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 				} else {
 					$checked	=	'';
 				}
-				$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<span class="cck_option_checkbox"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
 
 				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
 			}
@@ -225,7 +225,7 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 					} else {
 						$checked	=	'';
 					}
-					$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+					$form		.=	'<span class="cck_option_checkbox"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
 					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
 				}
 			}
@@ -233,7 +233,7 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 		if ( $field->bool7 ) {
 			$checked	=	( $count == $count2 ? '1' : '' ) ? 'checked="checked" ' : '';
 			$attr		=	'onclick="Joomla.checkAll(this,\''.$id.'\');"';
-			$check_all	=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
+			$check_all	=	'<span class="cck_option_checkbox"><input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
 						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label></span>';
 			if ( $field->bool && $field->bool2 > 1 && $count > 1 ) {
 				$check_all	=	'<div class="cck-clrfix">'.$check_all.'</div>';

--- a/plugins/cck_field/checkbox/checkbox.php
+++ b/plugins/cck_field/checkbox/checkbox.php
@@ -199,9 +199,9 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 				} else {
 					$checked	=	'';
 				}
-				$form		.=	'<input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
 
-				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label>';
+				$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
 			}
 			$form		.=	'</div>';
 		} else {
@@ -225,16 +225,16 @@ class plgCCK_FieldCheckbox extends JCckPluginField
 					} else {
 						$checked	=	'';
 					}
-					$form		.=	'<input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label>';
+					$form		.=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.$i.'" name="'.$name.'[]" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+					$form		.=	'<label for="'.$id.$i.'">'.$o->text.'</label></span>';
 				}
 			}
 		}
 		if ( $field->bool7 ) {
 			$checked	=	( $count == $count2 ? '1' : '' ) ? 'checked="checked" ' : '';
 			$attr		=	'onclick="Joomla.checkAll(this,\''.$id.'\');"';
-			$check_all	=	'<input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
-						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label>';
+			$check_all	=	'<span class="cck_checkbox_option"><input type="checkbox" id="'.$id.'_toggle'.'" name="'.$name.'_toggle" value="" '.$checked.$attr.' />'
+						.	'<label for="'.$id.'_toggle">'.JText::_( 'COM_CCK_CHECK_ALL' ).'</label></span>';
 			if ( $field->bool && $field->bool2 > 1 && $count > 1 ) {
 				$check_all	=	'<div class="cck-clrfix">'.$check_all.'</div>';
 			}

--- a/plugins/cck_field/radio/radio.php
+++ b/plugins/cck_field/radio/radio.php
@@ -191,8 +191,8 @@ class plgCCK_FieldRadio extends JCckPluginField
 				$k++;
 				$attr2		=	( isset( $o->$attr_key ) ) ? $o->$attr_key : '';
 				$checked	=	( $o->value == $value ) ? 'checked="checked" ' : '';
-				$form		.=	'<input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label>';
+				$form		.=	'<span class="cck_option_radio"><input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label></span>';
 
 				$indexes[$name]++;
 			}
@@ -201,8 +201,8 @@ class plgCCK_FieldRadio extends JCckPluginField
 			foreach ( $opts as $i=>$o ) {
 				$attr2		=	( isset( $o->$attr_key ) ) ? $o->$attr_key : '';
 				$checked	=	( $o->value == $value ) ? 'checked="checked" ' : '';
-				$form		.=	'<input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label>';
+				$form		.=	'<span class="cck_option_radio"><input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label></span>';
 
 				$indexes[$name]++;
 			}

--- a/plugins/cck_field/radio/radio.php
+++ b/plugins/cck_field/radio/radio.php
@@ -162,11 +162,13 @@ class plgCCK_FieldRadio extends JCckPluginField
 			$attr		=	'class="'.$class.'"' . ( $field->attributes ? ' '.$field->attributes : '' );
 			$form_open	=	'<fieldset id="'.$id.'" '.$attr.'>';
 			$attr		=	'class="'.$validate.'" size="1"';
+			$span = false;
 		} else {
 			$class		=	'radios'.$orientation . ( $field->css ? ' '.$field->css : '' );
 			$attr		=	'class="'.$class.'"' . ( $field->attributes ? ' '.$field->attributes : '' );
 			$form_open	=	'<fieldset id="'.$id.'" '.$attr.'>';
 			$attr		=	'class="radio'.$validate.'" size="1"';
+			$span = true;
 		}
 		$attr_key		=	'data-cck';
 		$form			=	'';
@@ -191,8 +193,10 @@ class plgCCK_FieldRadio extends JCckPluginField
 				$k++;
 				$attr2		=	( isset( $o->$attr_key ) ) ? $o->$attr_key : '';
 				$checked	=	( $o->value == $value ) ? 'checked="checked" ' : '';
-				$form		.=	'<span class="cck_option_radio"><input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label></span>';
+				$form		.= $span ? '<span class="cck_option_radio">' : '';
+				$form		.=	'<input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label>';
+				$form		.= $span ? '</span>' : '';
 
 				$indexes[$name]++;
 			}
@@ -201,8 +205,10 @@ class plgCCK_FieldRadio extends JCckPluginField
 			foreach ( $opts as $i=>$o ) {
 				$attr2		=	( isset( $o->$attr_key ) ) ? $o->$attr_key : '';
 				$checked	=	( $o->value == $value ) ? 'checked="checked" ' : '';
-				$form		.=	'<span class="cck_option_radio"><input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
-				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label></span>';
+				$form		.= $span ? '<span class="cck_option_radio">' : '';
+				$form		.=	'<input type="radio" id="'.$id.$indexes[$name].'" name="'.$name.'" value="'.$o->value.'" '.$checked.$attr.$attr2.' />';
+				$form		.=	'<label for="'.$id.$indexes[$name].'">'.$o->text.'</label>';
+				$form		.= $span ? '</span>' : '';
 
 				$indexes[$name]++;
 			}


### PR DESCRIPTION
The HTML of each checkbox and radio option is not presented with a class so it's impossible to style the option, in particular to keep the checkbox/radio and its label together on the same line.
This PR adds a class to the output HTML code of the option to allow CSS styling of options.