### PR TITLE
Define $error

### DIFF
--- a/plugins/cck_field_validation/ajax_availability/ajax_availability.php
+++ b/plugins/cck_field_validation/ajax_availability/ajax_availability.php
@@ -117,6 +117,7 @@ class plgCCK_Field_ValidationAjax_Availability extends JCckPluginValidation
 	// _check
 	protected static function _check( $validation, $value, $config, $and = '' )
 	{
+		$error = FALSE;
 		if ( $config['pk'] > 0 ) {
 			$count	=	(int)JCckDatabase::loadResult( 'SELECT '.$validation->key.' FROM '.$validation->table
 					.	' WHERE '.$validation->column.' = "'.JCckDatabase::escape( $value ).'"'.$and );


### PR DESCRIPTION
Define $error as FALSE to exclude NOTICE messages when $error doesn't become TRUE.
