### PR TITLE
Avoid importing empty tag title

### DIFF
--- a/plugins/cck_field/jform_tag/jform_tag.php
+++ b/plugins/cck_field/jform_tag/jform_tag.php
@@ -197,6 +197,8 @@ class plgCCK_FieldJform_Tag extends JCckPluginField
 				
 				foreach ( $values as $value ) {
 					$value		=	trim( $value );
+					
+					if (empty($value)) continue;
 
 					$parent_id	=	$config['params']['unknown_tags'] ? $config['params']['tags_parent'] : $default_id;
 					$parts		=	explode( $config['glue'], $value );


### PR DESCRIPTION
An import can fail due to an empty tag title. This occurs if there is a trailing comma at the end of a list of tags supplied in an import file. If a tag to import is empty, skip it.