### PR TITLE
Strip whitespace from imported tag title

### DIFF
--- a/plugins/cck_field/jform_tag/jform_tag.php
+++ b/plugins/cck_field/jform_tag/jform_tag.php
@@ -202,6 +202,8 @@ class plgCCK_FieldJform_Tag extends JCckPluginField
 					$parts		=	explode( $config['glue'], $value );
 
 					foreach ( $parts as $part ) {
+						$part = trim( $part );
+						
 						$pk	=	(int)JCckDatabaseCache::loadResult( 'SELECT id FROM #__tags WHERE published != -2 AND title = "'.$part.'"' );
 
 						if ( !$pk ) {


### PR DESCRIPTION
## Issue:
White space around a tag name supplied in an import file (for example, if there is white space after a comma in a list of tags) may result in a tag not getting 'tagged' on the newly imported article, even if the tag already exists. This is because the tag field will attempt to create a new tag with the white space, but the alias that Joomla creates will collide with the existing tag, and the creation fails silently.

## Fix:
In `onCCK_FieldPrepareImport()`, before querying for an existing tag, or potentially creating a new tag, trim the whitespace around the tag name. This allows for a comma-separated list of tags to imported from an import file, using ", " (comma then space) as a separator. 