### PR TITLE
Fix to retrieve stored processing/export id value

### DIFF
--- a/plugins/cck_field/button_submit/button_submit.php
+++ b/plugins/cck_field/button_submit/button_submit.php
@@ -187,7 +187,15 @@ class plgCCK_FieldButton_Submit extends JCckPluginField
 		$options2	=	JCckDev::fromJSON( $field->options2 );
 		$task		=	( isset( $options2['task'] ) && $options2['task'] ) ? $options2['task'] : 'save';
 		$task_auto	=	( isset( $options2['task_auto'] ) && $options2['task_auto'] == '0' ) ? 0 : 1;
-		$task_id	=	( isset( $options2['task_id'] ) && $options2['task_id'] ) ? $options2['task_id'] : 0;
+
+		$task2			=	str_replace( '_ajax', '', $task );
+		$task_id_idx	=	'task_id';
+
+		if ( $task2 == 'export' || $task2 == 'process' ) {
+			$task_id_idx	=	'task_id_' . $task2;
+		}
+
+		$task_id	=	( isset( $options2[$task_id_idx] ) && $options2[$task_id_idx] ) ? $options2[$task_id_idx] : 0;
 
 		if ( JFactory::getApplication()->isClient( 'administrator' ) ) {
 			$task	=	( $config['client'] == 'admin' ) ? 'form.'.$task : 'list.'.$task;

--- a/plugins/cck_field/button_submit/button_submit.php
+++ b/plugins/cck_field/button_submit/button_submit.php
@@ -187,15 +187,7 @@ class plgCCK_FieldButton_Submit extends JCckPluginField
 		$options2	=	JCckDev::fromJSON( $field->options2 );
 		$task		=	( isset( $options2['task'] ) && $options2['task'] ) ? $options2['task'] : 'save';
 		$task_auto	=	( isset( $options2['task_auto'] ) && $options2['task_auto'] == '0' ) ? 0 : 1;
-
-		$task2			=	str_replace( '_ajax', '', $task );
-		$task_id_idx	=	'task_id';
-
-		if ( $task2 == 'export' || $task2 == 'process' ) {
-			$task_id_idx	=	'task_id_' . $task2;
-		}
-
-		$task_id	=	( isset( $options2[$task_id_idx] ) && $options2[$task_id_idx] ) ? $options2[$task_id_idx] : 0;
+		$task_id	=	( isset( $options2['task_id'] ) && $options2['task_id'] ) ? $options2['task_id'] : 0;
 
 		if ( JFactory::getApplication()->isClient( 'administrator' ) ) {
 			$task	=	( $config['client'] == 'admin' ) ? 'form.'.$task : 'list.'.$task;

--- a/plugins/cck_field/button_submit/tmpl/edit.php
+++ b/plugins/cck_field/button_submit/tmpl/edit.php
@@ -21,7 +21,7 @@ if ( isset( $options2['task'] ) ) {
 	$options2_task	=	str_replace( '_ajax', '', $options2['task'] );
 
 	if ( $options2_task == 'export' || $options2_task == 'process' ) {
-		$task_id[$options2_task]	=	$options2['task_id'];
+		$task_id[$options2_task]	=	$options2['task_id_' . $options2_task];
 	}
 }
 ?>

--- a/plugins/cck_field_typo/date/date.php
+++ b/plugins/cck_field_typo/date/date.php
@@ -98,7 +98,7 @@ class plgCCK_Field_TypoDate extends JCckPluginTypo
 		$months			=	$interval->format( '%m' );
 		$days			=	$interval->format( '%d' );
 		$days_total		=	$interval->format( '%a' );
-        $state			=	( $date1 < $now ) ? 'COM_CCK_AGO_SENTENCE' : 'COM_CCK_TIMELEFT_SENTENCE';
+        $state			=	( $date1 <= $now ) ? 'COM_CCK_AGO_SENTENCE' : 'COM_CCK_TIMELEFT_SENTENCE';
 
 		if ( $limit && $days_total >= $limit ) {
 			$value		=	self::_getValueWithFormatStorage( $value );


### PR DESCRIPTION
The $options2_task suffix is missing in the $options2 index to correctly select the export or processing option in the field after store.