### PR TITLE
Add 'jform_accesslevel' to the list of loaded field types in admin for dev fields

### DIFF
--- a/administrator/components/com_cck/views/search/tmpl/edit.php
+++ b/administrator/components/com_cck/views/search/tmpl/edit.php
@@ -12,7 +12,7 @@ defined( '_JEXEC' ) or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 
-$config		=	JCckDev::init( array( '42', 'radio', 'select_dynamic', 'select_simple', 'text', 'wysiwyg_editor' ), true, array( 'item'=>$this->item, 'vName'=>$this->vName ) );
+$config		=	JCckDev::init( array( '42', 'radio', 'select_dynamic', 'select_simple', 'text', 'wysiwyg_editor', 'jform_accesslevel' ), true, array( 'item'=>$this->item, 'vName'=>$this->vName ) );
 $cck		=	JCckDev::preload( array( 'core_title_search', 'core_description', 'core_state',
 										 'core_location2', 'core_alias', 'core_access' ) );
 $lang		=	JFactory::getLanguage();

--- a/administrator/components/com_cck/views/type/tmpl/edit.php
+++ b/administrator/components/com_cck/views/type/tmpl/edit.php
@@ -12,7 +12,7 @@ defined( '_JEXEC' ) or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 
-$config		=	JCckDev::init( array( '42', 'jform_rules', 'radio', 'select_dynamic', 'select_simple', 'text', 'textarea', 'wysiwyg_editor' ), true, array( 'item'=>$this->item, 'vName'=>$this->vName ) );
+$config		=	JCckDev::init( array( '42', 'jform_rules', 'radio', 'select_dynamic', 'select_simple', 'text', 'textarea', 'wysiwyg_editor', 'jform_accesslevel' ), true, array( 'item'=>$this->item, 'vName'=>$this->vName ) );
 $cck		=	JCckDev::preload( array( 'core_title_type', 'core_description', 'core_state',
 										 'core_location', 'core_rules_type', 'core_parent_type', 'core_indexing', 'core_access' ) );
 $lang		=	JFactory::getLanguage();


### PR DESCRIPTION
Add the 'jform_accesslevel' field type to be loaded to avoid this error when loading a search or a type in backend :

0 call_user_func_array(): Argument #1 ($callback) must be a valid callback, class "plgCCK_Fieldjform_accesslevel" not found     