### PR TITLE
New tab names for permissions

### DIFF
--- a/plugins/cck_field/jform_rules/tmpl/form.php
+++ b/plugins/cck_field/jform_rules/tmpl/form.php
@@ -69,7 +69,7 @@ $js		=	'
 						var elem = "'.$this->item->id.'";
 						var data = {};
 						var val = key = idx = "";
-						$("#permissions-sliders select, #permissions-sliders input").each(function(i) {
+						$("#myTab select, #myTab input").each(function(i) {
 							var name = $(this).attr("name").split("][");
 							key = name[0].replace(elem+"[","");
 							idx = name[1].replace("]","");


### PR DESCRIPTION
The js code can not retrieve input & select values as per usergroup tabs have new IDs.

A fix with the correct tab name to let hte js code retrieve values and fill the data array to encode.