### PR TITLE
Fix null object on PHP8

### DIFF
--- a/plugins/cck_field/upload_file/includes/afterstore.php
+++ b/plugins/cck_field/upload_file/includes/afterstore.php
@@ -106,7 +106,9 @@ if ( $process['forbidden_ext'] ) {
 
 if ( JFile::upload( $tmp_name, $location, false, $allowUnsafe, $safeFileOptions ) ) {
 	$value					=	$file_location;
-	$fields[$name]->value	=	$value;
+	if( isset( $fields[$name] ) && is_object( $fields[$name] ) ) {
+		$fields[$name]->value	=	$value;
+	}
 } else {
 	$value					=	'';
 	


### PR DESCRIPTION
Fix for https://www.seblod.com/community/forums/forms-content-types/using-upload-image-with-php8-give-error

Tested on J3.10.11 / S3.22.3 / PHP 8.0.28

