### PR TITLE
Check if $value is an array before doing the count

### DIFF
--- a/plugins/cck_field/field_x/field_x.php
+++ b/plugins/cck_field/field_x/field_x.php
@@ -205,7 +205,7 @@ class plgCCK_FieldField_X extends JCckPluginField
 		$store	=	'';
 		$xk		=	0;
 		$xi		=	0;
-		if ( count( $value ) ) {
+		if ( is_array( $value ) && count( $value ) ) {
 			$store		=	'<br />';	//begin?
 			$f			=	self::_getChild( $field, $config );
 			$f_name		=	$f->name;


### PR DESCRIPTION
If not, raises an error on PHP 8(.1) website if fieldx is empty