### PR TITLE
To avoid "document.location.href='" & "'" to be added over javascript…

### DIFF
--- a/plugins/cck_field/button_free/button_free.php
+++ b/plugins/cck_field/button_free/button_free.php
@@ -227,8 +227,10 @@ class plgCCK_FieldButton_Free extends JCckPluginField
 				} elseif ( $field1->link ) {
 					if ( isset( $field1->link_target ) && $field1->link_target == '_blank' ) {
 						$onclick	=	'var otherWindow = window.open(); otherWindow.opener = null; otherWindow.location = \''.$field1->link.'\';';					
-					} else {
+					} elseif ( strpos( $field1->link, 'javascript:' ) === false ) {
 						$onclick	=	'document.location.href=\''.$field1->link.'\'';
+					} else {
+						$onclick	=	$field1->link;
 					}
 				} else {
 					$canDo		=	false;


### PR DESCRIPTION
**Issue** : When we configure the button free to preform a task and call a process, the javascript code is encapsuled in a 'document.location.href' which avoids the button to work.

Fix : Add a test to check if there's a "javascript" string in the link. No : add the 'document.location.href', Yes : Just set the link as it is.