### PR TITLE
Fix access error to params protected property

### DIFF
--- a/plugins/system/cck/cck.php
+++ b/plugins/system/cck/cck.php
@@ -455,7 +455,7 @@ class plgSystemCCK extends JPlugin
 								$item		=	$app->getMenu()->getItem( $itemId2 );
 								$urlvars	=	'';
 								if ( is_object( $item ) ) {
-									$urlvars	=	$item->params->get( 'urlvars' );
+									$urlvars	=	$item->getParams()->get( 'urlvars' );
 
 									if ( $urlvars != '' ) {
 										$urlvars	=	'&'.$urlvars;


### PR DESCRIPTION
params is a protected property of the Joomla menuitem object and has to be accessed through the getParams() method