### PR TITLE
Set default value to NULL and authorize column to be NULL for DATE & DATETIME column types

### DIFF
--- a/libraries/cck/_/plugin/field.php
+++ b/libraries/cck/_/plugin/field.php
@@ -294,18 +294,22 @@ class JCckPluginField extends JPlugin
 			}
 			if ( $data['alterTable'] ) {
 				$data['storage_alter_type']		=	( isset( $data['storage_alter_type'] ) && $data['storage_alter_type'] ) ? $data['storage_alter_type'] : 'VARCHAR(255)';
-				$default						=	'';
+				$default						=	'""';
+				$not_null						=	' NOT NULL';
 				$alter							=	isset( $data['storage_alter'] ) && $data['storage_alter'] && in_array( 1, $data['storage_alter'] );
 				$pos							=	strpos( $data['storage_table'], 'aka_table' );
 				$data['storage_alter_table']	=	(int)$data['storage_alter_table'];
 
 				if ( strpos( $data['storage_alter_type'], 'TEXT' ) !== false || strpos( $data['storage_alter_type'], 'CHAR' ) !== false ) {
 					//
+				} elseif ( strpos( $data['storage_alter_type'], 'DATE' ) === 0 ) {
+					$default	=	'NULL';
+					$not_null	=	'';
 				} else {
 					$default	=	'0';
 				}
 
-				$default						=	' DEFAULT "'.$default.'"';
+				$default						=	' DEFAULT '.$default;
 
 				if ( !( $pos !== false && $pos == 0 ) ) {
 					if ( isset( $data['storage_alter_table'] ) && $data['storage_alter_table'] && $alter ) {
@@ -313,12 +317,12 @@ class JCckPluginField extends JPlugin
 							$columns	=	$db->getTableColumns( $data['storage_table'] );
 							if ( !isset( $columns[$data['storage_field']] ) ) {
 								if ( $data['storage_alter_table'] == 2 && $data['storage_field_prev'] != '' ) {
-									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' CHANGE '.JCckDatabase::quoteName( $data['storage_field_prev'] ).' '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].' NOT NULL'.$default );
+									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' CHANGE '.JCckDatabase::quoteName( $data['storage_field_prev'] ).' '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].$not_null.$default );
 								} else {
-									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' ADD '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].' NOT NULL'.$default );
+									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' ADD '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].$not_null.$default );
 								}							
 							} else {
-								JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' CHANGE '.JCckDatabase::quoteName( $data['storage_field'] ).' '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].' NOT NULL'.$default );
+								JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' CHANGE '.JCckDatabase::quoteName( $data['storage_field'] ).' '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].$not_null.$default );
 							}
 						}
 					} else {
@@ -344,12 +348,12 @@ class JCckPluginField extends JPlugin
 								}
 								$columns2	=	$db->getTableColumns( $table );
 								if ( !isset( $columns2[$data['storage_field']] ) ) {
-									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $table ).' ADD '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].' NOT NULL'.$default );
+									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $table ).' ADD '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].$not_null.$default );
 								}
 								$data['storage_table']	=	$table;
 							} else {
 								if ( $alter ) {
-									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' CHANGE '.JCckDatabase::quoteName( $data['storage_field'] ).' '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].' NOT NULL'.$default );
+									JCckDatabase::execute( 'ALTER TABLE '.JCckDatabase::quoteName( $data['storage_table'] ).' CHANGE '.JCckDatabase::quoteName( $data['storage_field'] ).' '.JCckDatabase::quoteName( $data['storage_field'] ).' '.$data['storage_alter_type'].$not_null.$default );
 								}
 							}
 						}


### PR DESCRIPTION
This code fixes the error on saving fields on J4.x/S4.1.1 with storage column type set as DATE or DATETIME. It sets default value to NULL instead of 0 and conditionally removes the 'NOT NULL' option in the SQL Query.