### PR TITLE
Fix error on saving new multi-site

### DIFF
--- a/administrator/components/com_cck/install/install.sql
+++ b/administrator/components/com_cck/install/install.sql
@@ -557,7 +557,7 @@ CREATE TABLE IF NOT EXISTS `#__cck_core_sites` (
   `context` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
   `aliases` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL,
   `guest` int(10) UNSIGNED NOT NULL,
-  `guest_only_group` int(10) UNSIGNED NOT NULL,
+  `guest_only_group` int(10) UNSIGNED NOT NULL DEFAULT '0',
   `guest_only_viewlevel` int(10) UNSIGNED NOT NULL DEFAULT '0',
   `usergroups` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `users` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,


### PR DESCRIPTION
https://www.seblod.com/community/forums/fields-plug-ins/seblod-4-multi-site-field-guest-only-group-doesn-t-have-a-default-value

If you need a quick fix on your website, you can run this SQL query :
`ALTER TABLE `#__cck_core_sites` CHANGE `guest_only_group` `guest_only_group` INT(10) UNSIGNED NOT NULL DEFAULT '0';`