### PR TITLE
Update list_inc.php

### DIFF
--- a/libraries/cck/base/list/list_inc.php
+++ b/libraries/cck/base/list/list_inc.php
@@ -132,6 +132,7 @@ if ( $isPersistent == 1 || ( $isPersistent == 2 && $user->id && !$user->guest ) 
 }
 
 // Variations
+$variation      =       '';
 $variation	=	explode( '||', $variation );
 $variations	=	array();
 


### PR DESCRIPTION
Fixing notice of PHP 8.1
"Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated"