### PR TITLE
Update joomla_article.php

### DIFF
--- a/plugins/cck_storage_location/joomla_article/joomla_article.php
+++ b/plugins/cck_storage_location/joomla_article/joomla_article.php
@@ -958,7 +958,7 @@ class plgCCK_Storage_LocationJoomla_Article extends JCckPluginLocation
 		// Retrieve Content Type(s)
 		if ( isset( $config['sef_types'] ) && $config['sef_types'] != '' ) {
 			if ( $config['doSEF'][0] != '3' ) {
-				$join	.=	' LEFT JOIN #__cck_core AS e on e.'.$config['join_key'].' = a.id';
+				$join	.=	' LEFT JOIN #__cck_core AS e on e.'.$config['join_key'].' = b.id';
 				$where	.=	( strpos( $config['sef_types'], ',' ) !== false ) ? ' AND e.cck IN ("'.str_replace( ',', '","', $config['sef_types'] ).'")' : ' AND e.cck = "'.$config['sef_types'].'"';
 			}
 		}


### PR DESCRIPTION
As I see you try join `#__content as a` to `#__cck_core as e` with value `e.cck='category'` - value for joomla_category object. We took `$config` from Menu Item which set for Search in Category Object. Maybe it would be more clean in [ this topic ](https://www.seblod.com/community/forums/forms-content-types/replay-native-joomla-structure)