### PR TITLE
Remove Deprecated notice with empty field description

### DIFF
--- a/libraries/cck/_/plugin/field.php
+++ b/libraries/cck/_/plugin/field.php
@@ -851,7 +851,7 @@ class JCckPluginField extends JPlugin
 			if ( trim( $field->label ) ) {
 				$field->label	=	JText::_( 'COM_CCK_' . str_replace( ' ', '_', trim( $field->label ) ) );
 			}
-			if ( trim( $field->description ) ) {
+			if ( $field->description) {
 				$desc	=	trim( strip_tags( $field->description ) );
 				if ( $desc ) {
 					$field->description	=	JText::_( 'COM_CCK_' . str_replace( ' ', '_', $desc ) );


### PR DESCRIPTION
This `trim` isn't really needed here, but PHP 8+ shows a message like ```Deprecated: trim(): Passing null to parameter #1  of type string is deprecated``` when field description is empty. `trim` will be applied in next string without any problems.