### PR TITLE
Update link.php to exclude Deprecated message

### DIFF
--- a/plugins/cck_field/link/link.php
+++ b/plugins/cck_field/link/link.php
@@ -129,7 +129,7 @@ class plgCCK_FieldLink extends JCckPluginField
 		$value			=	( $value != '' ) ? $value : $field->defaultvalue;
 		$value			=	( $value != ' ' ) ? $value : '';
 		$value			=	JCckDev::fromJSON( $value );
-		$value['text']	=	htmlspecialchars( @$value['text'], ENT_QUOTES );
+		$value['text']	=	htmlspecialchars( @$value['text'] ?? '', ENT_QUOTES );
 		$preview		=	'';
 		
 		// Validate


### PR DESCRIPTION

`` Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /plugins/cck_field/link/link.php on line 132``

This message we see after opening User Create Form in Joomla. The best way I see for now - to use or null coalescing operator.
![image](https://github.com/Octopoos/SEBLOD/assets/4967754/976830ed-21df-4297-bd41-909d7d9f226f)