### PR TITLE
Support category with 3th level

### DIFF
--- a/plugins/cck_storage_location/joomla_category/joomla_category.php
+++ b/plugins/cck_storage_location/joomla_category/joomla_category.php
@@ -844,7 +844,7 @@ class plgCCK_Storage_LocationJoomla_Category extends JCckPluginLocation
 		if ( $vars['id'] == 0 ) {
 			throw new Exception( JText::_( 'JGLOBAL_CATEGORY_NOT_FOUND' ), 404 );
 		} else {
-			if ( ( JCck::on( '4.0' ) || !JCck::on( '4.0' ) && JComponentHelper::getParams( 'com_content' )->get( 'sef_advanced', 0 ) ) && ( $n == 1 || $n == 2 ) ) {
+			if ( ( JCck::on( '4.0' ) || !JCck::on( '4.0' ) && JComponentHelper::getParams( 'com_content' )->get( 'sef_advanced', 0 ) ) && ( $n == 1 || $n == 2 || $n == 3 ) ) {
 				$segments	=	array();
 			}
 		}


### PR DESCRIPTION
Hi. I didn't clear completely what did I do with this action, but I was needed to support native route for 3 levels of categories. So, I have it after this correction.  Pay your attention, please - why the router supported 2 levels only?

Situation: I heed to support native Joomla route for such url: ```http://site.ru/cat_lvl1_alias/cat_lvl2_alias/cat_lvl3_alias/article_alias``` I have done menu item for 1st lvl category, but next levels have to be without menu items. Maybe you can correct this code for all levels in such situation?
Thanks