### PR TITLE
Update search.php to fix error in first load

### DIFF
--- a/administrator/components/com_cck/models/search.php
+++ b/administrator/components/com_cck/models/search.php
@@ -181,10 +181,6 @@ class CCKModelSearch extends JCckBaseLegacyModelAdmin
 			if ( isset( $raw_data['ffp'] ) ) {
 				$data['ffp']	=	$raw_data['ffp'];
 			}
-			
-            		if (!isset($data['ff'])) {
-             		   $data['ff'] = [];
-          		}
 				
 			$this->storeMore( $pk, $data['client'], $data['ff'], $data['ffp'] );
 
@@ -276,7 +272,7 @@ class CCKModelSearch extends JCckBaseLegacyModelAdmin
 		$method	=	'gm_getConstruction_Values_Search';
 		
 		JCckDatabase::execute( 'DELETE FROM #__cck_core_'.$table.' WHERE searchid = '.(int)$searchId . ' AND client = "'.$client.'"' );
-		if ( count( $fields ) ) {
+		if ( is_countable($fields) && count( $fields ) ) {
 			$assigned	=	'';
 			$ordering	=	1;
 			$position	=	'mainbody';

--- a/administrator/components/com_cck/models/search.php
+++ b/administrator/components/com_cck/models/search.php
@@ -181,6 +181,10 @@ class CCKModelSearch extends JCckBaseLegacyModelAdmin
 			if ( isset( $raw_data['ffp'] ) ) {
 				$data['ffp']	=	$raw_data['ffp'];
 			}
+			
+            		if (!isset($data['ff'])) {
+             		   $data['ff'] = [];
+          		}
 				
 			$this->storeMore( $pk, $data['client'], $data['ff'], $data['ffp'] );
 


### PR DESCRIPTION
To replay this error:
1) Create a new Search
2) Go to List tab
3) Choose a list template.
Reaction: first time you have an error like "Oops. Reload this page" - ajax returns error 500 (count of NULL). After reload page works normally. To remove this behavior I added this checking