### PR TITLE
Correction of the thumb path

### DIFF
--- a/plugins/cck_field/upload_image/upload_image.php
+++ b/plugins/cck_field/upload_image/upload_image.php
@@ -386,7 +386,7 @@ class plgCCK_FieldUpload_Image extends JCckPluginField
 										<img title="'.$title_image.'" alt="'.$desc_image.'" src="'.JUri::root().$value['image_location'].'" />
 									</a>';
 				} else {
-					$thumb_location	=	str_replace( $title,'_thumb'.( $options2['form_preview'] - 2 ).'/'.$title,$value['image_location'] );
+					$thumb_location	=	str_replace( '/'.$title.'.','/_thumb'.( $options2['form_preview'] - 2 ).'/'.$title.'.',$value['image_location'] );
 					$preview	=	'<a href="'.JUri::root().$value['image_location'].'" '.$attr_preview.' title="'.$title_colorbox.'">
 										<img title="'.$title_image.'" alt="'.$desc_image.'" src="'.JUri::root().$thumb_location.'" />
 									</a>';


### PR DESCRIPTION
There is an error when filename is a part of article id. For example filename is "4.jpg" and article id is "324". Path to file is "/images/type_name/324/4.jpg", but path to thumb in this case is "/images/type_name/32_thumb1/4/_thumb1/4.jpg". So, such thumb is anavailiable.
My correction limits filename between slash and dot to define filename more clear.