### PR TITLE
Update ui.css remove paddings from .inputbox

### DIFF
--- a/administrator/components/com_cck/assets/css/ui.css
+++ b/administrator/components/com_cck/assets/css/ui.css
@@ -143,7 +143,6 @@ div.seblod .inputbox {
 	-webkit-border-radius: 3px;
 	-moz-border-radius: 3px;
 	border-radius:3px;
-	padding: 4px 6px;
 }
 div.seblod .thin {
 	-webkit-border-radius: 3px;


### PR DESCRIPTION
Remove this padding to stay them from template. These paddings are too small.
This view WITHOUT paddings:
![image](https://github.com/user-attachments/assets/69cd1fa9-e0f5-4c91-8eb9-ace3039b943f)
And this view WITH paddings:
![image](https://github.com/user-attachments/assets/ad97026d-0454-4736-acc5-c99c24a8cd9f)

