### PR TITLE
Fix timezone shift in search when using date-only input

### DIFF
--- a/plugins/cck_field/jform_calendar/jform_calendar.php
+++ b/plugins/cck_field/jform_calendar/jform_calendar.php
@@ -205,7 +205,7 @@ class plgCCK_FieldJform_Calendar extends JCckPluginField
 			return $field;
 		}
 	}
-	
+
 	// onCCK_FieldPrepareSearch
 	public function onCCK_FieldPrepareSearch( &$field, $value = '', &$config = array(), $inherit = array(), $return = false )
 	{
@@ -214,19 +214,28 @@ class plgCCK_FieldJform_Calendar extends JCckPluginField
 		}
 		$value	=	trim( $value );
 
-		if ( (int)$value > 0 ) {
-			$date		=	JFactory::getDate( $value, $this->userTimeZone );
+		if ((int)$value > 0) {
+			$options2 = JCckDev::fromJSON($field->options2);
+			$modify = (isset($options2['modify']) && $options2['modify']) ? $options2['modify'] : '';
 
-			$options2	=	JCckDev::fromJSON( $field->options2 );
-			$modify		=	( isset( $options2['modify'] ) && $options2['modify'] ) ? $options2['modify'] : '';
+		// Detect if the value includes a time
+		$hasTime = strpos($value, ':') !== false;
 
-			if ( $modify ) {
-				$date->modify( $modify );
-			}
-			$timezone	=	new DateTimeZone( 'UTC' );
-			$date->setTimezone( $timezone );
-			$value		=	$date->toSql();
+		// Prevent timezone shift to previous day
+		if (!$hasTime) {
+			$value .= ' 12:00:00';
 		}
+
+		$date = JFactory::getDate($value, $this->userTimeZone);
+
+		if ($modify) {
+			$date->modify($modify);
+		}
+
+		$timezone = new DateTimeZone('UTC');
+		$date->setTimezone($timezone);
+		$value = $date->toSql();
+	}
 
 		// Prepare
 		self::onCCK_FieldPrepareForm( $field, $value, $config, $inherit, $return );


### PR DESCRIPTION
This pull request addresses the issue described in [Issue #679](https://github.com/Octopoos/SEBLOD/issues/679), where the `calendar` field in search mode returns results from the previous day when Joomla is configured with a timezone other than UTC.

## Bug: calendar search field returns previous day when Joomla timezone ≠ UTC

When using the `calendar` field in search mode (`onCCK_FieldPrepareSearch`), and Joomla is configured with a timezone like GMT+2, searching for a specific date (e.g. `2025-05-27`) returns items from the previous day.

This is due to the fact that date-only inputs (e.g. `2025-05-27`) are interpreted as midnight in the local timezone (`2025-05-27 00:00:00`), and then converted to UTC (`2025-05-26 22:00:00`), which shifts the intended search range.

## Solution

The fix adds a check to detect whether the input date string includes a time component. If not, it appends `12:00:00` before the conversion to UTC. This avoids the unintended shift to the previous day.

Added in `onCCK_FieldPrepareSearch()`:

```php
$hasTime = strpos($value, ':') !== false;

if (!$hasTime) {
    $value .= ' 12:00:00'; // Prevent timezone shift to previous day
}
```
## Scope

- This fix only affects search forms.
-  It does not affect how values are stored or displayed elsewhere.
- It is compatible with modify settings (like -1 day), and has been tested across different Joomla timezone settings.

Thanks for maintaining Seblod. I hope this small fix will help others experiencing this issue.