### PR TITLE
Fix: allow null values for empty date fields in JCckTable::store()

### DIFF
--- a/libraries/cck/_/table.php
+++ b/libraries/cck/_/table.php
@@ -104,5 +104,24 @@ class JCckTable extends JCckTablePlaceholder
 		$this->check();
 		$this->store();
 	}
+
+	public function store($updateNulls = false)
+	{
+		$fields = $this->getFields();
+		foreach ($fields as $field => $definition) {
+			if (
+				isset($this->$field) &&
+				$this->$field === '' &&
+				isset($definition->Type) &&
+				stripos($definition->Type, 'date') !== false
+			) {
+				$this->$field = null;
+			}
+		}
+
+		return parent::store($updateNulls);
+	}
+
 }
 ?>
+


### PR DESCRIPTION
This PR addresses the issue discussed in the SEBLOD community forum: [JForm - Calendar field has more than one problem](https://www.seblod.com/community/forums/fields-plug-ins/jform-calendar-field-has-more-than-one-problem), where optional date fields saved with an empty string ('') cause SQL errors in MySQL when the target column does not accept non-date values.

Previously, Olivier attempted to resolve this with [PR #773](https://github.com/Octopoos/SEBLOD/pull/773), which set the default value to NULL and allowed the column to be NULL for DATE & DATETIME column types. While this addressed the issue of creating the field from the backend, it did not fully resolve the problem of saving null values when the date field is left empty in the form.

### What’s the problem?

In many MySQL setups, saving an empty string into a DATE or DATETIME column throws an error like:

```Incorrect date value: '' for column `table`.`column_name` at row 1```

This happens even when the database column is nullable.

### What’s the fix?

We override the store() method in JCckTable to inspect the fields about to be saved. If a value is '' and the column is a date/datetime type, we convert it to null.

```
public function store($updateNulls = false)
{
    $fields = $this->getFields();
    foreach ($fields as $field => $definition) {
        if (
            isset($this->$field) &&
            $this->$field === '' &&
            isset($definition->Type) &&
            stripos($definition->Type, 'date') !== false
        ) {
            $this->$field = null;
        }
    }

    return parent::store($updateNulls);
}
```


### Why here?

This is a safe and generic fix at the database layer. It avoids plugin-specific workarounds, ensures data integrity, and respects optional field behavior without touching required logic.

I hope this small contribution will help others who need to save optional date fields without error, and also those who had to switch the SQL Mode to Legacy (Joomla! 3) in SEBLOD’s global options specifically because of this issue with empty date fields. With this change, SEBLOD should now work correctly using the recommended Auto (Newest) SQL Mode for this case.

Thank you for maintaining such a powerful and flexible CCK.
All the best
Adonay